### PR TITLE
رسم الخريطة المصغرة وتصحيح اتجاه اللاعب

### DIFF
--- a/src/files/ft_draw_mini_map.c
+++ b/src/files/ft_draw_mini_map.c
@@ -70,7 +70,7 @@ void	ft_draw_grids(t_data *dt)
 				if (dt->map[y][x] == '1')
 				{
 					wall_sq.x = (x - dt->player.x + VIEW_RD) * dt->shape_size;
-					wall_sq.y = (y - dt->player.y + VIEW_RD) * dt->shape_size;
+					wall_sq.y = (VIEW_RD - (y - dt->player.y)) * dt->shape_size;
 					wall_sq.size = dt->shape_size;
 					wall_sq.color = ft_rgb_to_uint32(84, 204, 154);
 					ft_draw_square(dt->s_frame, wall_sq);
@@ -96,7 +96,7 @@ void	ft_draw_player(t_data *dt)
 	player_sq.color = ft_rgb_to_uint32(255, 0, 0);
 	ft_draw_square(dt->s_frame, player_sq);
 	line_x = center + dt->dir_x * dt->shape_size;
-	line_y = center + dt->dir_y * dt->shape_size;
+	line_y = center - dt->dir_y * dt->shape_size;
 	ft_draw_line_direction(dt->s_frame, center, line_x, line_y);
 }
 


### PR DESCRIPTION
Invert mini-map Y-axis calculations to correct player movement direction and grid display.

The mini-map was displaying upside down because the screen's Y-axis (increasing downwards) was not correctly mapped to the game's Y-axis (increasing upwards for 'north'). This change inverts the Y-axis calculations for both the grid elements and the player's direction line, ensuring the mini-map accurately reflects player movement and orientation.

---
<a href="https://cursor.com/background-agent?bcId=bc-fef6fc59-fe28-4ee4-8bde-7b3a41a6bdf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fef6fc59-fe28-4ee4-8bde-7b3a41a6bdf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

